### PR TITLE
Add uint64 support support as SexpUint64

### DIFF
--- a/tests/uint.zy
+++ b/tests/uint.zy
@@ -1,0 +1,2 @@
+// Max uint64 value, will overflow an int64
+(x := 18446744073709551615)

--- a/zygo/expressions.go
+++ b/zygo/expressions.go
@@ -73,6 +73,10 @@ type SexpInt struct {
 	Val int64
 	Typ *RegisteredType
 }
+type SexpUint64 struct {
+	Val uint64
+	Typ *RegisteredType
+}
 type SexpBool struct {
 	Val bool
 	Typ *RegisteredType
@@ -97,6 +101,10 @@ func (r SexpStr) Type() *RegisteredType {
 
 func (r *SexpInt) Type() *RegisteredType {
 	return GoStructRegistry.Registry["int64"]
+}
+
+func (r *SexpUint64) Type() *RegisteredType {
+	return GoStructRegistry.Registry["uint64"]
 }
 
 func (r *SexpFloat) Type() *RegisteredType {
@@ -461,6 +469,10 @@ func (i *SexpInt) SexpString(ps *PrintState) string {
 	return strconv.Itoa(int(i.Val))
 }
 
+func (i *SexpUint64) SexpString(ps *PrintState) string {
+	return strconv.FormatUint(i.Val, 10)
+}
+
 func (f *SexpFloat) SexpString(ps *PrintState) string {
 	return strconv.FormatFloat(f.Val, 'f', 2, SexpFloatSize)
 }
@@ -622,6 +634,8 @@ func IsTruthy(expr Sexp) bool {
 	case *SexpBool:
 		return e.Val
 	case *SexpInt:
+		return e.Val != 0
+	case *SexpUint64:
 		return e.Val != 0
 	case *SexpChar:
 		return e.Val != 0

--- a/zygo/numerictower.go
+++ b/zygo/numerictower.go
@@ -26,6 +26,8 @@ func IntegerDo(op IntegerOp, a, b Sexp) (Sexp, error) {
 	switch i := a.(type) {
 	case *SexpInt:
 		ia = i
+	case *SexpUint64:
+		return UintegerDo(op, i, b)
 	case *SexpChar:
 		ia = &SexpInt{Val: int64(i.Val)}
 	default:
@@ -35,6 +37,8 @@ func IntegerDo(op IntegerOp, a, b Sexp) (Sexp, error) {
 	switch i := b.(type) {
 	case *SexpInt:
 		ib = i
+	case *SexpUint64:
+		return UintegerDo(op, &SexpUint64{Val: uint64(ia.Val)}, b)
 	case *SexpChar:
 		ib = &SexpInt{Val: int64(i.Val)}
 	default:
@@ -56,6 +60,39 @@ func IntegerDo(op IntegerOp, a, b Sexp) (Sexp, error) {
 		return &SexpInt{Val: ia.Val | ib.Val}, nil
 	case BitXor:
 		return &SexpInt{Val: ia.Val ^ ib.Val}, nil
+	}
+	return SexpNull, errors.New("unrecognized shift operation")
+}
+
+func UintegerDo(op IntegerOp, ia *SexpUint64, b Sexp) (Sexp, error) {
+	var ib *SexpUint64
+
+	switch i := b.(type) {
+	case *SexpUint64:
+		ib = i
+	case *SexpInt:
+		ib = &SexpUint64{Val: uint64(i.Val)}
+	case *SexpChar:
+		ib = &SexpUint64{Val: uint64(i.Val)}
+	default:
+		return SexpNull, WrongType
+	}
+
+	switch op {
+	case ShiftLeft:
+		return &SexpUint64{Val: ia.Val << ib.Val}, nil
+	case ShiftRightArith:
+		return &SexpUint64{Val: ia.Val >> ib.Val}, nil
+	case ShiftRightLog:
+		return &SexpUint64{Val: ia.Val >> ib.Val}, nil
+	case Modulo:
+		return &SexpUint64{Val: ia.Val % ib.Val}, nil
+	case BitAnd:
+		return &SexpUint64{Val: ia.Val & ib.Val}, nil
+	case BitOr:
+		return &SexpUint64{Val: ia.Val | ib.Val}, nil
+	case BitXor:
+		return &SexpUint64{Val: ia.Val ^ ib.Val}, nil
 	}
 	return SexpNull, errors.New("unrecognized shift operation")
 }
@@ -106,12 +143,34 @@ func NumericIntDo(op NumericOp, a, b *SexpInt) Sexp {
 	return SexpNull
 }
 
+func NumericUint64Do(op NumericOp, a, b *SexpUint64) Sexp {
+	switch op {
+	case Add:
+		return &SexpUint64{Val: a.Val + b.Val}
+	case Sub:
+		return &SexpUint64{Val: a.Val - b.Val}
+	case Mult:
+		return &SexpUint64{Val: a.Val * b.Val}
+	case Div:
+		if a.Val%b.Val == 0 {
+			return &SexpUint64{Val: a.Val / b.Val}
+		} else {
+			return &SexpFloat{Val: float64(a.Val) / float64(b.Val)}
+		}
+	case Pow:
+		return &SexpUint64{Val: uint64(math.Pow(float64(a.Val), float64(b.Val)))}
+	}
+	return SexpNull
+}
+
 func NumericMatchFloat(op NumericOp, a *SexpFloat, b Sexp) (Sexp, error) {
 	var fb *SexpFloat
 	switch tb := b.(type) {
 	case *SexpFloat:
 		fb = tb
 	case *SexpInt:
+		fb = &SexpFloat{Val: float64(tb.Val)}
+	case *SexpUint64:
 		fb = &SexpFloat{Val: float64(tb.Val)}
 	case *SexpChar:
 		fb = &SexpFloat{Val: float64(tb.Val)}
@@ -127,8 +186,24 @@ func NumericMatchInt(op NumericOp, a *SexpInt, b Sexp) (Sexp, error) {
 		return NumericFloatDo(op, &SexpFloat{Val: float64(a.Val)}, tb), nil
 	case *SexpInt:
 		return NumericIntDo(op, a, tb), nil
+	case *SexpUint64:
+		return NumericUint64Do(op, &SexpUint64{Val: uint64(a.Val)}, tb), nil
 	case *SexpChar:
 		return NumericIntDo(op, a, &SexpInt{Val: int64(tb.Val)}), nil
+	}
+	return SexpNull, WrongType
+}
+
+func NumericMatchUint64(op NumericOp, a *SexpUint64, b Sexp) (Sexp, error) {
+	switch tb := b.(type) {
+	case *SexpFloat:
+		return NumericFloatDo(op, &SexpFloat{Val: float64(a.Val)}, tb), nil
+	case *SexpInt:
+		return NumericUint64Do(op, a, &SexpUint64{Val: uint64(tb.Val)}), nil
+	case *SexpUint64:
+		return NumericUint64Do(op, a, tb), nil
+	case *SexpChar:
+		return NumericUint64Do(op, a, &SexpUint64{Val: uint64(tb.Val)}), nil
 	}
 	return SexpNull, WrongType
 }
@@ -140,6 +215,8 @@ func NumericMatchChar(op NumericOp, a *SexpChar, b Sexp) (Sexp, error) {
 		res = NumericFloatDo(op, &SexpFloat{Val: float64(a.Val)}, tb)
 	case *SexpInt:
 		res = NumericIntDo(op, &SexpInt{Val: int64(a.Val)}, tb)
+	case *SexpUint64:
+		return NumericUint64Do(op, &SexpUint64{Val: uint64(a.Val)}, tb), nil
 	case *SexpChar:
 		res = NumericIntDo(op, &SexpInt{Val: int64(a.Val)}, &SexpInt{Val: int64(tb.Val)})
 	default:
@@ -160,6 +237,8 @@ func NumericDo(op NumericOp, a, b Sexp) (Sexp, error) {
 		return NumericMatchFloat(op, ta, b)
 	case *SexpInt:
 		return NumericMatchInt(op, ta, b)
+	case *SexpUint64:
+		return NumericMatchUint64(op, ta, b)
 	case *SexpChar:
 		return NumericMatchChar(op, ta, b)
 	}

--- a/zygo/parser.go
+++ b/zygo/parser.go
@@ -362,24 +362,52 @@ func (parser *Parser) ParseExpression(depth int) (res Sexp, err error) {
 	case TokenDecimal:
 		i, err := strconv.ParseInt(tok.str, 10, SexpIntSize)
 		if err != nil {
+			e := err.(*strconv.NumError)
+			if e.Err == strconv.ErrRange {
+				i, err := strconv.ParseUint(tok.str, 10, 64)
+				if err == nil {
+					return &SexpUint64{Val: i}, nil
+				}
+			}
 			return SexpNull, err
 		}
 		return &SexpInt{Val: i}, nil
 	case TokenHex:
 		i, err := strconv.ParseInt(tok.str, 16, SexpIntSize)
 		if err != nil {
+			e := err.(*strconv.NumError)
+			if e.Err == strconv.ErrRange {
+				i, err := strconv.ParseUint(tok.str, 16, 64)
+				if err == nil {
+					return &SexpUint64{Val: i}, nil
+				}
+			}
 			return SexpNull, err
 		}
 		return &SexpInt{Val: i}, nil
 	case TokenOct:
 		i, err := strconv.ParseInt(tok.str, 8, SexpIntSize)
 		if err != nil {
+			e := err.(*strconv.NumError)
+			if e.Err == strconv.ErrRange {
+				i, err := strconv.ParseUint(tok.str, 8, 64)
+				if err == nil {
+					return &SexpUint64{Val: i}, nil
+				}
+			}
 			return SexpNull, err
 		}
 		return &SexpInt{Val: i}, nil
 	case TokenBinary:
 		i, err := strconv.ParseInt(tok.str, 2, SexpIntSize)
 		if err != nil {
+			e := err.(*strconv.NumError)
+			if e.Err == strconv.ErrRange {
+				i, err := strconv.ParseUint(tok.str, 2, 64)
+				if err == nil {
+					return &SexpUint64{Val: i}, nil
+				}
+			}
 			return SexpNull, err
 		}
 		return &SexpInt{Val: i}, nil


### PR DESCRIPTION
Addresses my own feature request, #39 

The tests could probably do with some work and it definitely needs a once-over from the maintainer, though. I'd also like to have some way of coercing values to uint64 without just relying on overflows.