### PR TITLE
fix Makefile by adding installation instructions for convey and gls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ build:
 	/bin/echo "package zygo" > zygo/gitcommit.go
 	/bin/echo "func init() { GITLASTTAG = \"$(shell git describe --abbrev=0 --tags)\"; GITLASTCOMMIT = \"$(shell git rev-parse HEAD)\" }" >> zygo/gitcommit.go
 	go install github.com/glycerine/zygomys/cmd/zygo
-
+	go install github.com/glycerine/goconvey/convey
+	go install github.com/jtolds/gls
 test:
 	tests/testall.sh && echo "running 'go test'" && cd zygo && go test -v


### PR DESCRIPTION
Without this addition to the Makefile, users would run into an error that the `convey` and `gls` packages are not found on the user's system. 