### PR TITLE
Delay allocating stacktrace buffer until necessary

### DIFF
--- a/zygo/environment.go
+++ b/zygo/environment.go
@@ -360,15 +360,15 @@ func (env *Zlisp) CallUserFunction(
 	// protect against bad calls/bad reflection in usercalls
 	var wasPanic bool
 	var recovered interface{}
-	tr := make([]byte, 16384)
-	trace := &tr
+	var trace []byte
 	res, err := func() (Sexp, error) {
 		defer func() {
 			recovered = recover()
 			if recovered != nil {
 				wasPanic = true
-				nbyte := runtime.Stack(*trace, false)
-				*trace = (*trace)[:nbyte]
+				trace = make([]byte, 16384)
+				nbyte := runtime.Stack(trace, false)
+				trace = trace[:nbyte]
 			}
 		}()
 
@@ -382,7 +382,7 @@ func (env *Zlisp) CallUserFunction(
 	if wasPanic {
 		err = fmt.Errorf("CallUserFunction caught panic during call of "+
 			"'%s': '%v'\n stack trace:\n%v\n",
-			name, recovered, string(*trace))
+			name, recovered, string(trace))
 	}
 	if err != nil {
 		return 0, errors.New(

--- a/zygo/environment_test.go
+++ b/zygo/environment_test.go
@@ -2,8 +2,9 @@ package zygo
 
 import (
 	"fmt"
-	cv "github.com/glycerine/goconvey/convey"
 	"testing"
+
+	cv "github.com/glycerine/goconvey/convey"
 )
 
 func Test400SandboxFunctions(t *testing.T) {
@@ -58,4 +59,18 @@ func Test400SandboxFunctions(t *testing.T) {
 
 		}
 	})
+}
+
+func BenchmarkCallUserFunction(b *testing.B) {
+	env := NewZlisp()
+	env.AddFunction("dosomething", func(*Zlisp, string, []Sexp) (r Sexp, err error) { return })
+	script := fmt.Sprintf(`
+		(for [(def i 0) (< i 1000000) (set i (+ i 1))]
+			(dosomething)
+		)
+	`)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		env.EvalString(script)
+	}
 }

--- a/zygo/environment_test.go
+++ b/zygo/environment_test.go
@@ -61,16 +61,15 @@ func Test400SandboxFunctions(t *testing.T) {
 	})
 }
 
-func BenchmarkCallUserFunction(b *testing.B) {
-	env := NewZlisp()
-	env.AddFunction("dosomething", func(*Zlisp, string, []Sexp) (r Sexp, err error) { return })
-	script := fmt.Sprintf(`
-		(for [(def i 0) (< i 1000000) (set i (+ i 1))]
-			(dosomething)
-		)
-	`)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		env.EvalString(script)
-	}
+func TestCallUserFunction(t *testing.T) {
+	cv.Convey(`It should recover from user-land panics and give stack traces`, t, func() {
+		env := NewZlisp()
+		env.AddFunction("dosomething", func(*Zlisp, string, []Sexp) (r Sexp, err error) {
+			panic("I don't know how to do anything")
+		})
+		_, err := env.EvalString("(dosomething)")
+		cv.So(err, cv.ShouldNotBeNil)
+		cv.So(err.Error(), cv.ShouldContainSubstring, "stack trace:")
+		cv.So(err.Error(), cv.ShouldContainSubstring, "github.com/glycerine/zygomys/zygo.(*Zlisp).CallUserFunction")
+	})
 }


### PR DESCRIPTION
Right now `CallUserFunction` will always allocate a byte slice to store stack traces. Delaying the allocation of the byte slice until it is absolutely necessary drastically increases the performance of this method (~3x on my machine).

Potential downside of this is that we might be unable to allocate memory when the panic occurs. However, I think go will still give us a pretty solid error message in that case.