### PR TITLE
fix go.mod version to v6 according workflow https://go.dev/doc/module…

### DIFF
--- a/cmd/zygo/main.go
+++ b/cmd/zygo/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/glycerine/zygomys/zygo"
+	"github.com/glycerine/zygomys/v6/zygo"
 	"os"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/glycerine/zygomys
+module github.com/glycerine/zygomys/v6
 
 go 1.14
 


### PR DESCRIPTION
this PR fixes the following issues:

1) the docs https://pkg.go.dev/github.com/glycerine/zygomys have  latest tag ```v5.1.2+incompatible``` but repository contains ```v6.0.3```

2) ```go get github.com/glycerine/zygomys@v6.0.3``` does not work, because

https://proxy.golang.org/github.com/glycerine/zygomys/@v/v6.0.3.info returns:

```
not found: github.com/glycerine/zygomys@v6.0.3: invalid version: module contains a go.mod file, so module path must match major version ("github.com/glycerine/zygomys/v6")
```

Additional info https://go.dev/ref/mod#incompatible-versions

UP:
https://go.dev/ref/mod#minimal-module-compatibility

``` minimal module compatibility was added in Go 1.11 and was backported to Go 1.9.7 and 1.10.3. When an import path is resolved to a directory in GOPATH mode```

this means that the Golang minimum compatible version cannot be lower than 1.9.7 after PR applied