### PR TITLE
fix resource leak in repl

### DIFF
--- a/zygo/repl.go
+++ b/zygo/repl.go
@@ -457,6 +457,7 @@ func ReplMain(cfg *ZlispConfig) {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
+    defer f.Close()
 		err = pprof.StartCPUProfile(f)
 		if err != nil {
 			fmt.Println(err)
@@ -464,7 +465,6 @@ func ReplMain(cfg *ZlispConfig) {
 		}
 		defer func() {
 			pprof.StopCPUProfile()
-			f.Close()
 		}()
 	}
 

--- a/zygo/repl.go
+++ b/zygo/repl.go
@@ -457,7 +457,7 @@ func ReplMain(cfg *ZlispConfig) {
 			fmt.Println(err)
 			os.Exit(-1)
 		}
-    defer f.Close()
+    		defer f.Close()
 		err = pprof.StartCPUProfile(f)
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
When starting ```CpuProfile``` fails with error you exit the program but don't close the file. This PR fixes it.