### PR TITLE
fix: correct typo 'unkown' → 'unknown' in panic message

### DIFF
--- a/zygo/jsonmsgp.go
+++ b/zygo/jsonmsgp.go
@@ -998,7 +998,7 @@ func SexpToGoStructs(
 					//vv("upperKey = '%v' from recordKey = '%v'; found=%v; det='%#v'", upperKey, recordKey, found, det)
 					if !found {
 						fmt.Printf(" skipping field '%s' in this hash/which we could not find in the JsonTagMap", recordKey)
-						panic(fmt.Sprintf("unkown field '%s' not allowed; could not find in the JsonTagMap. Fieldnames are case sensitive. src.JstonTagMap: '%#v'", recordKey, src.JsonTagMap))
+						panic(fmt.Sprintf("unknown field '%s' not allowed; could not find in the JsonTagMap. Fieldnames are case sensitive. src.JstonTagMap: '%#v'", recordKey, src.JsonTagMap))
 						continue
 					}
 				}


### PR DESCRIPTION
## Summary
Corrects the typo `unkown field` → `unknown field` in `zygo/jsonmsgp.go` panic message (line ~1001).

## Changes
- Fix typo `unkown` → `unknown` in panic message for unknown JSON field errors

## Testing
- Go build verified on the modified code

---
*Submitted via PR-fast automation (Jah-yee <jydu_seven@outlook.com>)*